### PR TITLE
Actions fix

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,8 +2,9 @@ name: Publish to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
+  pull_request:
+  schedule:
+    - cron: '0 0 1 * *'  # run workflow at 12AM on first day of every month
 
 jobs:
   build:


### PR DESCRIPTION
Creates the sub-directory needed for the documentation to build.

Also alters the GitHub Actions to run monthly on a cron job, and run for any push or pull request. The stage with the deployment was already tucked behind an if-statement and will only run on the "main" branch when the action is successful.